### PR TITLE
Add picture feature improved. Can upload from anywhere in the computer

### DIFF
--- a/app/Http/Controllers/PlayersController.php
+++ b/app/Http/Controllers/PlayersController.php
@@ -84,8 +84,17 @@ class PlayersController extends Controller
         $player->playing_hand = $request->playing_hand; 
         $player->backhand_style = $request->backhand_style;
         $player->briefing = $request->briefing;
-        $picture_path = ($request->picture == "") ? "images/player.png" : "images/$request->picture";
-        $player->picture_route = $picture_path;
+        //$picture_path = ($request->picture == "") ? "images/player.png" : "images/$request->picture";
+        if (!$request->hasFile('picture')) {
+            $picture_path = 'images/' . "player.png";
+            $player->picture_route = $picture_path;
+        } else {
+            $fileName = time() . '.' . $request->picture->extension();
+            $picture_path = 'images/' . $fileName;
+            $request->picture->move(public_path('images'), $fileName);
+            
+            $player->picture_route = $picture_path;
+        }
         //$player->created_at = $request->playing_hand;
         //$player->updated_at = $request->playing_hand;
 
@@ -121,7 +130,13 @@ class PlayersController extends Controller
         $player->playing_hand = $request->playing_hand; 
         $player->backhand_style = $request->backhand_style;
         $player->briefing = $request->briefing;
-        $player->picture_route = ($request->picture_route == "") ? $player->picture_route : "images/$request->picture_route";
+        $fileName = time() . '.' . $request->picture->extension();
+        $picture_path = 'images/' . $fileName;
+        $request->picture->move(public_path('images'), $fileName);
+        //$picture_path = ($request->picture == "") ? "images/player.png" : "images/$request->picture";
+        $player->picture_route = $picture_path;
+        //$player->created_at = $request->playing_hand;
+        //$player->updated_at = $request->playing_hand;
 
         //$player->created_at = $request->playing_hand;
         //$player->updated_at = $request->playing_hand;

--- a/database/migrations/2024_11_03_093704_create_players_table.php
+++ b/database/migrations/2024_11_03_093704_create_players_table.php
@@ -18,8 +18,8 @@ return new class extends Migration
             $table->integer('ranking');
             $table->string('email')->unique();
             $table->integer('height');
-            $table->string('playing_hand');
-            $table->string('backhand_style');
+            $table->enum('playing_hand', ['left', 'right']);
+            $table->enum('backhand_style', ['one hand', 'two hands']);
             $table->text('briefing');
             $table->string('picture_route')->nullable;
             $table->timestamps();

--- a/database/migrations/2024_11_09_194939_create_challenges_table.php
+++ b/database/migrations/2024_11_09_194939_create_challenges_table.php
@@ -13,8 +13,10 @@ return new class extends Migration
     {
         Schema::create('challenges', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('player1_id')->constrained('players')->onUpdate('cascade');
-            $table->foreignId('player2_id')->constrained('players')->onUpdate('cascade');
+            $table->foreignId('player1_id');
+            $table->foreignId('player2_id');
+            //$table->foreignId('player1_id')->constrained('players')->onUpdate('cascade');
+            //$table->foreignId('player2_id')->constrained('players')->onUpdate('cascade');
             $table->integer('p1_set1');
             $table->integer('p1_set2');
             $table->integer('p1_set3')->nullable;

--- a/resources/views/challenges/challenges.blade.php
+++ b/resources/views/challenges/challenges.blade.php
@@ -20,11 +20,23 @@
     @foreach ($challenges as $challenge)
         <tr class="">
             <td class="px-1 py-1">{{$challenge[10]}}</td>
+            @if ($challenge[1] == "")
+                @php
+                    $challenge[0] = "Deleted";
+                    $challenge[1] = "player";
+                @endphp
+            @endif
             <td class="px-1 py-1">{{$challenge[0]}}</td>
             <td class="px-1 py-1"> {{$challenge[1]}}</td>
             <td class="px-1 py-1"> {{$challenge[4]}} - {{$challenge[7]}}</td>
             <td class="px-1 py-1"> {{$challenge[5]}} - {{$challenge[8]}}</td>
             <td class="px-1 py-1"> {{$challenge[6]}} - {{$challenge[9]}}</td>
+            @if ($challenge[3] == "")
+                @php
+                    $challenge[2] = "Deleted";
+                    $challenge[3] = "player";
+                @endphp
+            @endif
             <td class="px-1 py-1">{{$challenge[2]}}</td>
             <td class="px-1 py-1"> {{$challenge[3]}}</td>
 

--- a/resources/views/players/add.blade.php
+++ b/resources/views/players/add.blade.php
@@ -3,7 +3,7 @@
         
       <x-lista :players="$players" />
         <div class="w-2/5 bg-blue-200 shadow-2xl h-auto p-10 mx-5 rounded-2xl flex flex-col items-center">
-            <form class="w-full max-w-sm"  id="nuevo" name="nuevo" method="POST"  action="{{asset('/')}}player/save" autocomplete="off">
+            <form class="w-full max-w-sm"  id="nuevo" name="nuevo" method="POST"  action="{{asset('/')}}player/save" enctype="multipart/form-data" autocomplete="off">
                 @csrf
                 <div class="md:flex md:items-center mb-6">
                 <div class="md:w-1/3">
@@ -99,7 +99,6 @@
                 </div>
                 <div class="md:w-2/3">
                   <input class="bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" type="file" id="picture" name="picture">
-                  <p class="text-xs">(picture must be located at public/images)</p>
                 </div>
               </div>
               

--- a/resources/views/players/edit.blade.php
+++ b/resources/views/players/edit.blade.php
@@ -3,7 +3,7 @@
       <x-lista :players="$players" />
 
         <div class="w-2/5 bg-blue-200 shadow-2xl h-auto p-10 mx-5 rounded-2xl flex flex-col items-center">
-            <form class="w-full max-w-sm"  id="nuevo" name="nuevo" method="POST"  action="{{asset('/')}}player/{{$player->id}}" autocomplete="off">
+            <form class="w-full max-w-sm"  id="nuevo" name="nuevo" method="POST"  action="{{asset('/')}}player/{{$player->id}}" enctype="multipart/form-data" autocomplete="off">
                 
                 @csrf
                 @method('PUT')
@@ -102,8 +102,7 @@
                   </label>
                 </div>
                 <div class="md:w-2/3">
-                  <input class="bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" type="file" id="picture_route" name="picture_route"">
-                  <p class="text-xs">(picture must be located at public/images)</p>
+                  <input class="bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500" type="file" id="picture" name="picture">
                 </div>
               </div>
               


### PR DESCRIPTION
Before this improvement, the picture of the player had to be placed in advance in /images folder before registering the player.
Now the picture can be uploaded from anywhere in the computer.
A couple of little thins also improved:
- backhand and playing_hand fields changed to enum in migrations
- If a player is deleted, his challenges against existing players will be shown as "deleted player"